### PR TITLE
use new $*LANG.define_slang interface

### DIFF
--- a/lib/Slang/Tuxic.pm
+++ b/lib/Slang/Tuxic.pm
@@ -42,7 +42,13 @@ sub EXPORT(|) {
         }
     }
     my Mu $MAIN-grammar := nqp::atkey(%*LANG, 'MAIN');
-    nqp::bindkey(%*LANG, 'MAIN', $MAIN-grammar.HOW.mixin($MAIN-grammar, Tuxic));
+    my $grammar := $MAIN-grammar.HOW.mixin($MAIN-grammar, Tuxic);
+
+
+    # old way
+    try nqp::bindkey(%*LANG, 'MAIN', $grammar);
+    # new way
+    try $*LANG.define_slang('MAIN', $grammar, $*LANG.actions);
 
     {}
 }


### PR DESCRIPTION
This will update Slang::Tuxic to work with either the old or the new slang definition interface.